### PR TITLE
Increase timeout to 300seconds

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -55,7 +55,7 @@ Resources:
                 Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
             MemorySize: 320
             Runtime: java8
-            Timeout: 30
+            Timeout: 300
     ApiFrontend:
         DependsOn: APIPermission
         Type: AWS::ApiGateway::Method


### PR DESCRIPTION
This lambda has a problem that when users post forms to it, it often times out and rejects their submission. It usually works a second time, but this is not good enough for reader facing tech. 

I think this happens because the JVM takes a while to warm up on first requests. 

Ideal solution - is to rewrite this lambda as typescript 
Short solution - is to bump up the timeout, which is what I've done here.  

Lots of Guardian lambdas have a `300` timeout. 
cc - [this one](https://github.com/guardian/fulfilment-node-stub-lambda/blob/master/cloudformation.yaml#L64), and [this one ](https://github.com/guardian/affiliate-link-checker/blob/master/cloudformation.yaml#L36)